### PR TITLE
Fix #44 future deprecation

### DIFF
--- a/src/fuzzylogic/classes.py
+++ b/src/fuzzylogic/classes.py
@@ -486,7 +486,7 @@ def rule_from_table(table: str, references: dict):
 
     import pandas as pd
 
-    df = pd.read_table(io.StringIO(table), delim_whitespace=True)
+    df = pd.read_table(io.StringIO(table), sep='\s+')
 
     D: dict[tuple[Any, Any], Any] = {
         (


### PR DESCRIPTION
I tested it with this custom table and worked (just because I didn't understand the tests in repo)
```
            upg.norte_e upg.este  upg.sur upg.oeste upg.norte_o
upv.norte_e     uv.baja uv.media  uv.alta  uv.media     uv.baja
   upv.este    uv.media  uv.baja uv.media   uv.alta    uv.media
    upv.sur     uv.alta uv.media  uv.baja  uv.media     uv.alta
  upv.oeste    uv.media  uv.alta uv.media   uv.baja    uv.media
upv.norte_o     uv.baja uv.media  uv.alta  uv.media     uv.baja
```

Anyway, I don't think it will have any problems.